### PR TITLE
hashed email is not an email, but an array if alternate_email is left as primary email.

### DIFF
--- a/public/class-bosobi-shortcodes.php
+++ b/public/class-bosobi-shortcodes.php
@@ -120,7 +120,7 @@ class BOSOBI_Shortcodes {
 		$user_id = ( $user_id ) ? $user_id : get_current_user_id();
 		$email_alt_field = BOSOBI_Settings::get( 'alt_email' );
 
-		if ( $email_alt_field !== "" && get_user_meta( $user_id, $email_alt_field, true ) !== "" ){
+		if ( !empty($email_alt_field) && get_user_meta( $user_id, $email_alt_field, true ) !== "" ){
 			return get_user_meta( $user_id, $email_alt_field, true );
 		} else {
 			$user = get_userdata( $user_id );


### PR DESCRIPTION
 Hi Ardnived,
In api/badge.php, I noticed that if you install this and don't set the alternate email field, that that the hashed email is not the email but some array that contains email. 

Please confirm that this fixes it or that this is the case?  

Also, do you know much about what a negative response should be if assertion uid is invalid (aka user_id/page_id is invalid and assertion fails.  I tried to quickly look for what the response should be but not luck.

Best,
Loong
